### PR TITLE
VS code bug fix

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -27,7 +27,7 @@
 		
 		window.onload = function() {
 		
-		  var alarm= {{ alarm }};
+		  var alarm= '{{ alarm }}';
 		  
 	      if( alarm == "1" ){
 			alert("User or Password incorrect, please try again!");


### PR DESCRIPTION
VS code doesn't like declarations like this {{variable}} instead add single quotes '{{variable}}' to avoid error